### PR TITLE
Add `quaternion_rotate` function

### DIFF
--- a/pylinalg/func/quaternion.py
+++ b/pylinalg/func/quaternion.py
@@ -215,6 +215,16 @@ def quaternion_rotate(vector, quaternion, /, *, out=None, dtype=None):
     dtype : data-type, optional
         Overrides the data type of the result.
 
+    Returns
+    -------
+    rotated_vector : ndarray, [3]
+        The input vector rotated by the given quaternion.
+
+    Notes
+    -----
+    For improved accuracy consider normalizing the vector before applying the
+    rotation and then re-apply the original scale afterwards.
+
     """
 
     vector = np.asarray(vector, dtype=dtype)

--- a/pylinalg/func/quaternion.py
+++ b/pylinalg/func/quaternion.py
@@ -195,3 +195,37 @@ def quaternion_make_from_axis_angle(axis, angle, /, *, out=None, dtype=None):
     out[3] = np.cos(angle_half)
 
     return out
+
+
+def quaternion_rotate(vector, quaternion, /, *, out=None, dtype=None):
+    """
+    Rotate a vector using a quaternion.
+
+    Parameters
+    ----------
+    vector : ndarray, [3]
+        The vector to rotate in local space.
+    quaternion : ndarray, [4]
+        The quaternion to rotate by in ``(x, y, z, w)`` format.
+    out : ndarray, optional
+        A location into which the result is stored. If provided, it
+        must have a shape that the inputs broadcast to. If not provided or
+        None, a freshly-allocated array is returned. A tuple must have
+        length equal to the number of outputs.
+    dtype : data-type, optional
+        Overrides the data type of the result.
+
+    """
+
+    vector = np.asarray(vector, dtype=dtype)
+    quaternion = np.asarray(quaternion, dtype=dtype)
+
+    scalar = quaternion[..., -1]
+    q_vector = quaternion[..., :3]
+
+    # the required linalg products
+    q_v = np.tensordot(q_vector, vector, axes=(-1, -1))
+    q_q = np.tensordot(q_vector, q_vector, axes=(-1, -1))
+    qxv = np.cross(q_vector, vector, axis=-1)
+
+    return (2 * q_v * q_vector) + (scalar**2 - q_q) * vector + 2 * scalar * qxv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,27 @@ def rotation_matrix(axis, angle):
     return matrix
 
 
+@st.composite
+def unit_vector(
+    draw,
+    elements=st.floats(
+        allow_infinity=False, allow_nan=False, min_value=0, max_value=2 * np.pi
+    ),
+):
+    """
+    Generate a unit vector using a point on the unit-sphere
+    (essentially spherical coordinates to euclidean coordinates)
+    """
+    theta, phi = draw(elements), draw(elements)
+
+    # spherical to euclidean (r = 1)
+    x = cos(theta) * sin(phi)
+    y = sin(theta) * sin(phi)
+    z = cos(phi)
+
+    return np.array((x, y, z))
+
+
 def nonzero_scale(scale):
     return np.where(np.abs(scale) < EPS, 1, scale)
 
@@ -129,3 +150,4 @@ test_matrix_affine = arrays(float, (4, 4), elements=legal_numbers)
 test_scaling = arrays(float, (3,), elements=legal_numbers).map(nonzero_scale)
 test_dtype = dtype_string()
 test_angles_rad = arrays(float, (3,), elements=legal_angle)
+test_unit_vector = unit_vector()


### PR DESCRIPTION
This PR adds a function to the functional API that rotates a given vector using a quaternion without first converting it into a matrix. 

The current implementation is slower than its `matrix @ vector` variant, so I don't know if we want to add it in its current form or just do `matrix @ vector` internally. That said, I think it would be convenient to have this signature as part of the API :)