### PR TITLE
Implement vector rotation via quaternion

### DIFF
--- a/pylinalg/func/matrix.py
+++ b/pylinalg/func/matrix.py
@@ -304,13 +304,8 @@ def matrix_make_transform(translation, rotation, scaling, /, *, out=None, dtype=
 
 def matrix_decompose(matrix, /, *, dtype=None, out=None):
     """
-    Decompose a affine transformation matrix.
-
-    The input matrix is decomposed into a sequence of 5 matrices::
-
-        matrix = projection @ translation @ rotation @ shearing @ scaling
-
-    The individual matrices have the following form:
+    Decompose a transformation matrix into a translation vector, a
+    quaternion and a scaling vector.
 
     Parameters
     ----------
@@ -326,11 +321,8 @@ def matrix_decompose(matrix, /, *, dtype=None, out=None):
 
     Returns
     -------
-    projection : ndarray, [4]
-        The projection component of the matrix as a projection
     translation : ndarray, [3]
-        The translation component of the matrix as a displacement vector in the
-        source frame.
+        translation vector
     rotation : ndarray, [4]
         quaternion
     scaling : ndarray, [3]

--- a/pylinalg/func/matrix.py
+++ b/pylinalg/func/matrix.py
@@ -304,8 +304,13 @@ def matrix_make_transform(translation, rotation, scaling, /, *, out=None, dtype=
 
 def matrix_decompose(matrix, /, *, dtype=None, out=None):
     """
-    Decompose a transformation matrix into a translation vector, a
-    quaternion and a scaling vector.
+    Decompose a affine transformation matrix.
+
+    The input matrix is decomposed into a sequence of 5 matrices::
+
+        matrix = projection @ translation @ rotation @ shearing @ scaling
+
+    The individual matrices have the following form:
 
     Parameters
     ----------
@@ -321,8 +326,11 @@ def matrix_decompose(matrix, /, *, dtype=None, out=None):
 
     Returns
     -------
+    projection : ndarray, [4]
+        The projection component of the matrix as a projection
     translation : ndarray, [3]
-        translation vector
+        The translation component of the matrix as a displacement vector in the
+        source frame.
     rotation : ndarray, [4]
         quaternion
     scaling : ndarray, [3]

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -175,7 +175,7 @@ def vector_apply_quaternion_rotation(vector, quaternion, /, *, out=None, dtype=N
         The rotated vector.
 
     """
-    
+
     vector = np.asarray(vector, dtype=float)
     quaternion = np.asarray(quaternion, dtype=float)
 
@@ -188,11 +188,12 @@ def vector_apply_quaternion_rotation(vector, quaternion, /, *, out=None, dtype=N
     quat_vector = quaternion[..., :-1]
     quat_scalar = quaternion[..., -1]
 
-    out += 2 * np.sum(quat_vector*vector, axis=-1) * quat_vector
-    out += (quat_scalar ** 2 - np.sum(quat_vector*quat_vector, axis=-1)) * vector
+    out += 2 * np.sum(quat_vector * vector, axis=-1) * quat_vector
+    out += (quat_scalar**2 - np.sum(quat_vector * quat_vector, axis=-1)) * vector
     out += 2 * quat_scalar * np.cross(quat_vector, vector)
 
     return out
+
 
 def vector_spherical_to_euclidean(spherical, /, *, out=None, dtype=None):
     """Convert spherical -> euclidian coordinates.

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -175,9 +175,24 @@ def vector_apply_quaternion_rotation(vector, quaternion, /, *, out=None, dtype=N
         The rotated vector.
 
     """
+    
+    vector = np.asarray(vector, dtype=float)
+    quaternion = np.asarray(quaternion, dtype=float)
 
-    raise NotImplementedError()
+    if out is None:
+        out = np.zeros_like(vector, dtype=dtype)
 
+    # based on https://gamedev.stackexchange.com/a/50545
+    # (more readable than my attempt at doing the same)
+
+    quat_vector = quaternion[..., :-1]
+    quat_scalar = quaternion[..., -1]
+
+    out += 2 * np.sum(quat_vector*vector, axis=-1) * quat_vector
+    out += (quat_scalar ** 2 - np.sum(quat_vector*quat_vector, axis=-1)) * vector
+    out += 2 * quat_scalar * np.cross(quat_vector, vector)
+
+    return out
 
 def vector_spherical_to_euclidean(spherical, /, *, out=None, dtype=None):
     """Convert spherical -> euclidian coordinates.

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
-from hypothesis import example, given
+from hypothesis import given
 
 import pylinalg as pla
 

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -1,8 +1,11 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+from hypothesis import example, given
 
 import pylinalg as pla
+
+from .. import conftest as ct
 
 
 def test_vector_normalize():
@@ -127,3 +130,34 @@ def test_vector_apply_rotation_ordered():
         result,
         expected,
     )
+
+
+@given(ct.test_vector, ct.test_quaternion)
+def test_vector_apply_quaternion_rotation(vector, quaternion):
+    scale = np.linalg.norm(vector)
+    if scale > 1e100:
+        vector = vector / scale * 1e100
+
+    actual = pla.vector_apply_quaternion_rotation(vector, quaternion)
+
+    # reference implementation
+    matrix = pla.quaternion_to_matrix(quaternion)
+    vector = pla.vector_make_homogeneous(vector)
+    expected = (matrix @ vector)[..., :-1]
+
+    # assert relative proximity only
+    assert np.allclose(actual, expected, rtol=1e-10, atol=np.inf)
+
+
+@given(ct.test_vector, ct.test_quaternion)
+def test_vector_apply_quaternion_rotation_identity(vector, quaternion):
+    scale = np.linalg.norm(vector)
+    if scale > 1e100:
+        vector = vector / scale * 1e100
+
+    inv_quaternion = pla.quaternion_inverse(quaternion)
+    tmp = pla.vector_apply_quaternion_rotation(vector, quaternion)
+    actual = pla.vector_apply_quaternion_rotation(tmp, inv_quaternion)
+
+    # assert relative proximity only
+    assert np.allclose(actual, vector, rtol=1e-10, atol=np.inf)


### PR DESCRIPTION
Closes: https://github.com/pygfx/pylinalg/issues/13

This PR implements `vector_apply_quaternion_rotation`. It also adds property-based tests: (1) Identity (rotating by some quaternion and its inverse (approximately) yields the vector), (2) reference (compares the implementation against a reference implementation based on matrix multiplication).

This PR is RTR :)