### PR TITLE
Implement vector_unproject

### DIFF
--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -149,7 +149,26 @@ def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
         The unprojected vector in 3D space
     """
 
-    raise NotImplementedError()
+    vector = np.asarray(vector, dtype=float)
+    matrix = np.asarray(matrix, dtype=float)
+    depth = np.asarray(depth, dtype=float)
+
+    if out is None:
+        out = np.empty((*vector.shape[:-1], 3), dtype=dtype)
+
+    try:
+        inverse_projection = np.linalg.inv(matrix)
+    except np.linalg.LinAlgError:
+        raise ValueError("The provided matrix is not invertible.")
+
+    vector_hom = np.empty((*vector.shape[:-1], 4), dtype=dtype)
+    vector_hom[..., 0] = depth
+    vector_hom[..., [1, 2]] = vector
+    vector_hom[..., 3] = 0
+
+    out[:] = (inverse_projection @ vector_hom)[..., :-1]
+
+    return out
 
 
 def vector_apply_quaternion_rotation(vector, quaternion, /, *, out=None, dtype=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import hypothesis.strategies as st
 import numpy as np
 from hypothesis.extra.numpy import arrays, from_dtype
 
+import pylinalg as pla
+
 # upper bound on approximation error
 EPS = 1e-6
 
@@ -131,6 +133,60 @@ def unit_vector(
     return np.array((x, y, z))
 
 
+@st.composite
+def perspecitve_matrix(
+    draw, elements=st.floats(allow_infinity=False, allow_nan=False, min_value=1e-16)
+):
+    top, bottom = draw(elements), draw(elements)
+    hp.assume(top != bottom)
+
+    left, right = draw(elements), draw(elements)
+    hp.assume(left != right)
+
+    near, far = draw(elements), draw(elements)
+    hp.assume(near != far)
+    hp.assume(0 < near)
+    hp.assume(near < far)
+
+    matrix = pla.matrix_make_perspective(left, right, top, bottom, near, far)
+    hp.assume(not (np.any(np.isinf(matrix) | np.isnan(matrix))))
+
+    try:
+        np.linalg.inv(matrix)
+    except np.linalg.LinAlgError:
+        # only stable/invertible matrices
+        hp.assume(False)
+
+    return matrix
+
+
+@st.composite
+def orthographic_matrix(
+    draw, elements=st.floats(allow_infinity=False, allow_nan=False)
+):
+    top, bottom = draw(elements), draw(elements)
+    hp.assume(top != bottom)
+
+    left, right = draw(elements), draw(elements)
+    hp.assume(left != right)
+
+    near, far = draw(elements), draw(elements)
+    hp.assume(near != far)
+    hp.assume(0 < near)
+    hp.assume(near < far)
+
+    matrix = pla.matrix_make_orthographic(left, right, top, bottom, near, far)
+    hp.assume(not (np.any(np.isinf(matrix) | np.isnan(matrix))))
+
+    try:
+        np.linalg.inv(matrix)
+    except np.linalg.LinAlgError:
+        # only stable/invertible matrices
+        hp.assume(False)
+
+    return matrix
+
+
 def nonzero_scale(scale):
     return np.where(np.abs(scale) < EPS, 1, scale)
 
@@ -151,3 +207,4 @@ test_scaling = arrays(float, (3,), elements=legal_numbers).map(nonzero_scale)
 test_dtype = dtype_string()
 test_angles_rad = arrays(float, (3,), elements=legal_angle)
 test_unit_vector = unit_vector()
+test_projection = perspecitve_matrix() | orthographic_matrix()

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -126,6 +126,15 @@ def test_vector_unproject(expected, projection_matrix):
     assert np.allclose(actual, expected, rtol=1e-16, atol=np.inf)
 
 
+def test_vector_unproject_exceptions():
+    vector = np.ones(2)
+    matrix = np.eye(4)
+    matrix[1, 1] = 0
+
+    with pytest.raises(ValueError):
+        pla.vector_unproject(vector, matrix)
+
+
 def test_vector_apply_rotation_ordered():
     """Test that a positive pi/2 rotation about the z-axis and then the y-axis
     results in a different output then in standard rotation ordering."""

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -1,9 +1,10 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
-from hypothesis import given, assume
+from hypothesis import assume, given
 
 import pylinalg as pla
+
 from .. import conftest as ct
 
 


### PR DESCRIPTION
Closes: https://github.com/pygfx/pylinalg/issues/12

This PR implements the `vector_unproject` function. It is based on matrix inversion and thus not the most performant. However, this is the only way I can think of to "unproject" a generic projection matrix, i.e., without being able to make further assumptions about the type of projection (orthographic/perspective/...) or symmetry of the projection.

I also wrote a property-based test for `vector_unproject` and added hypothesis strategies to generate orthographic and perspective transformation matrices.