### PR TITLE
implement vector_spherical_to_euclidean

### DIFF
--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -185,7 +185,8 @@ def vector_spherical_to_euclidean(spherical, /, *, out=None, dtype=None):
     Parameters
     ----------
     spherical : ndarray, [3]
-        A vector in spherical coordinates (r, phi, theta).
+        A vector in spherical coordinates (r, phi, theta). Phi and theta are
+        measured in radians.
     out : ndarray, optional
         A location into which the result is stored. If provided, it
         must have a shape that the inputs broadcast to. If not provided or
@@ -202,7 +203,7 @@ def vector_spherical_to_euclidean(spherical, /, *, out=None, dtype=None):
     Notes
     -----
     This implementation follows pygfx's coordinate conventions. This means that
-    the positive y-axis is the zenith reference and the negative z-axis is the
+    the positive y-axis is the zenith reference and the positive z-axis is the
     azimuth reference. Angles are measured counter-clockwise.
 
     """
@@ -215,7 +216,7 @@ def vector_spherical_to_euclidean(spherical, /, *, out=None, dtype=None):
     r, theta, phi = np.split(spherical, 3, axis=-1)
     out[..., 0] = r * np.sin(phi) * np.sin(theta)
     out[..., 1] = r * np.cos(phi)
-    out[..., 2] = -r * np.sin(phi) * np.cos(theta)
+    out[..., 2] = r * np.sin(phi) * np.cos(theta)
 
     return out
 

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -199,9 +199,25 @@ def vector_spherical_to_euclidean(spherical, /, *, out=None, dtype=None):
     euclidean : ndarray, [3]
         A vector in euclidian coordinates.
 
+    Notes
+    -----
+    This implementation follows pygfx's coordinate conventions. This means that
+    the positive y-axis is the zenith reference and the negative z-axis is the
+    azimuth reference. Angles are measured counter-clockwise.
+
     """
 
-    raise NotImplementedError()
+    spherical = np.asarray(spherical, dtype=float)
+
+    if out is None:
+        out = np.empty_like(spherical, dtype=dtype)
+
+    r, theta, phi = np.split(spherical, 3, axis=-1)
+    out[..., 0] = r * np.sin(phi) * np.sin(theta)
+    out[..., 1] = r * np.cos(phi)
+    out[..., 2] = -r * np.sin(phi) * np.cos(theta)
+
+    return out
 
 
 def vector_distance_between(vector_a, vector_b, /, *, out=None, dtype=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,20 @@ EPS = 1e-6
 
 
 @st.composite
+def generate_spherical_vector(
+    draw,
+    radius=st.floats(min_value=0, max_value=360, allow_infinity=False, allow_nan=False),
+    theta=st.floats(
+        min_value=0, max_value=np.pi, allow_infinity=False, allow_nan=False
+    ),
+    phi=st.floats(
+        min_value=0, max_value=2 * np.pi, allow_infinity=False, allow_nan=False
+    ),
+):
+    return np.array((draw(radius), draw(theta), draw(phi)))
+
+
+@st.composite
 def generate_quaternion(
     draw,
     elements=st.floats(
@@ -150,4 +164,5 @@ test_matrix_affine = arrays(float, (4, 4), elements=legal_numbers)
 test_scaling = arrays(float, (3,), elements=legal_numbers).map(nonzero_scale)
 test_dtype = dtype_string()
 test_angles_rad = arrays(float, (3,), elements=legal_angle)
+test_spherical = generate_spherical_vector()
 test_unit_vector = unit_vector()

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -1,8 +1,11 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+from hypothesis import assume, given
 
 import pylinalg as pla
+
+from .. import conftest as ct
 
 
 def test_vector_normalize():
@@ -89,6 +92,48 @@ def test_vector_apply_matrix_out_dtype():
 
     assert result is out
     assert result.dtype == "i4"
+
+
+@given(ct.test_spherical)
+def test_vector_spherical_to_euclidean(spherical):
+    # accuracy of trigonometric ops close to 0, 90, 180, 270, 360 deg dependes a
+    # lot on the underlying hardware. Let's avoid it here.
+    angles = spherical[..., [1, 2]]
+    assume(np.all(np.abs(angles - 0) > 1e-100))
+    assume(np.all(np.abs(angles - np.pi / 2) > 1e-100))
+    assume(np.all(np.abs(angles - np.pi) > 1e-100))
+    assume(np.all(np.abs(angles - 2 * np.pi) > 1e-100))
+
+    # same for really short vectors (can produce 0)
+    assume(np.all(np.abs(spherical[0] - 0) > 1e-200))
+
+    # we can't do a simple round trip test. Instead we ensure that we are
+    # rotating in the right direction and that the radius/length match
+    result = pla.vector_spherical_to_euclidean(spherical)
+
+    # ensure azimuth rotates CCW
+    expected_sign = np.where(spherical[1] < np.pi / 2, -1, 1)
+    actual_sign = np.prod(np.sign(result[..., [0, 2]]))
+    assert np.all(expected_sign == actual_sign)
+
+    # ensure inclination is measured from positive y
+    expected_sign = np.where(spherical[2] < np.pi / 2, 1, -1)
+    expected_sign = np.where(spherical[2] > 3 / 2 * np.pi, 1, expected_sign)
+    actual_sign = np.sign(result[..., 1])
+    assert np.all(expected_sign == actual_sign)
+
+    # ensure length is what we expect
+    length = np.linalg.norm(result)
+    assert np.allclose(length, spherical[0], rtol=1e-16, atol=np.inf)
+
+
+def test_vector_spherical_to_euclidean_refs():
+    # ensure that the reference axes get transformed as expected
+    result = pla.vector_spherical_to_euclidean((1, 0, 0))
+    assert np.allclose(result, (0, 1, 0))
+
+    result = pla.vector_spherical_to_euclidean((1, 0, np.pi / 2))
+    assert np.allclose(result, (0, 0, -1))
 
 
 def test_vector_apply_rotation_about_z_matrix():

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -112,7 +112,7 @@ def test_vector_spherical_to_euclidean(spherical):
     result = pla.vector_spherical_to_euclidean(spherical)
 
     # ensure azimuth rotates CCW
-    expected_sign = np.where(spherical[1] < np.pi / 2, -1, 1)
+    expected_sign = np.where(spherical[1] < np.pi / 2, 1, -1)
     actual_sign = np.prod(np.sign(result[..., [0, 2]]))
     assert np.all(expected_sign == actual_sign)
 
@@ -133,7 +133,7 @@ def test_vector_spherical_to_euclidean_refs():
     assert np.allclose(result, (0, 1, 0))
 
     result = pla.vector_spherical_to_euclidean((1, 0, np.pi / 2))
-    assert np.allclose(result, (0, 0, -1))
+    assert np.allclose(result, (0, 0, 1))
 
 
 def test_vector_apply_rotation_about_z_matrix():


### PR DESCRIPTION
Closes: https://github.com/pygfx/pylinalg/issues/15

This PR implements the conversion from spherical coordinates to euclidean coordinates. It respects pygfx's convention for euclidean coordinates (y-axis up, negative z-axis forward). It also adds property-based tests to ensure that the transformation does the expected thing.