### PR TITLE
Implement vector_spherical_make_safe

### DIFF
--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -285,8 +285,8 @@ def vector_euclidean_to_spherical(euclidean, /, *, out=None, dtype=None):
 def vector_make_spherical_safe(vector, /, *, out=None, dtype=None):
     """Normalize sperhical coordinates.
 
-    Normalizes a vector of spherical coordinates to restrict phi to (eps, pi-eps) and
-    theta to (0, 2pi).
+    Normalizes a vector of spherical coordinates to restrict phi to [0, pi) and
+    theta to [0, 2pi).
 
     Parameters
     ----------
@@ -307,4 +307,19 @@ def vector_make_spherical_safe(vector, /, *, out=None, dtype=None):
 
     """
 
-    raise NotImplementedError()
+    vector = np.asarray(vector, dtype=float)
+
+    if out is None:
+        out = np.zeros_like(vector, dtype=dtype)
+
+    is_flipped = vector[..., 1] % (2 * np.pi) >= np.pi
+    out[..., 2] = np.where(is_flipped, -vector[..., 2], vector[..., 2])
+
+    out[..., 0] = vector[..., 0]
+    out[..., 1] = vector[..., 1] % np.pi
+    out[..., 2] = vector[..., 1] % (2 * np.pi)
+
+    out[..., 1] = np.where(out[..., 1] == np.pi, 0, out[..., 1])
+    out[..., 2] = np.where(out[..., 2] == 2 * np.pi, 0, out[..., 2])
+
+    return out

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -1,8 +1,11 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+from hypothesis import given
 
 import pylinalg as pla
+
+from .. import conftest as ct
 
 
 def test_vector_normalize():
@@ -53,6 +56,14 @@ def test_vector_apply_translation():
         result,
         expected,
     )
+
+
+@given(ct.test_vector)
+def test_vector_make_spherical_safe(vector):
+    result = pla.vector_make_spherical_safe(vector)
+
+    assert np.all((0 <= result[..., 1]) & (result[..., 1] < np.pi))
+    assert np.all((0 <= result[..., 2]) & (result[..., 2] < 2 * np.pi))
 
 
 def test_vector_apply_matrix_out():


### PR DESCRIPTION
Closes: https://github.com/pygfx/pylinalg/issues/18

This PR adds `vector_spherical_make_safe` and an accompanying property-based test to ensure that the result is indeed normalized. Once we have merged #35 we could also add a test that asserts that both vectors are equivalent in euclidean space (up to numerical errors).
