### PR TITLE
Implement vector_from_matrix_position

### DIFF
--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -254,7 +254,14 @@ def vector_from_matrix_position(homogeneous_matrix, /, *, out=None, dtype=None):
 
     """
 
-    raise NotImplementedError()
+    homogeneous_matrix = np.asarray(homogeneous_matrix, dtype=float)
+
+    if out is None:
+        out = np.empty((*homogeneous_matrix.shape[:-2], 3), dtype=dtype)
+
+    out[:] = homogeneous_matrix[..., :-1, -1]
+
+    return out
 
 
 def vector_euclidean_to_spherical(euclidean, /, *, out=None, dtype=None):

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -1,8 +1,11 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+from hypothesis import given
 
 import pylinalg as pla
+
+from .. import conftest as ct
 
 
 def test_vector_normalize():
@@ -41,6 +44,14 @@ def test_vector_make_homogeneous(vectors, value, expected):
     expected = np.asarray(expected)
     result = pla.vector_make_homogeneous(vectors, w=value)
     npt.assert_array_equal(result, expected)
+
+
+@given(ct.test_vector)
+def test_vector_from_matrix_position(translation):
+    matrix = pla.matrix_make_translation(translation)
+    result = pla.vector_from_matrix_position(matrix)
+
+    npt.assert_equal(result, translation)
 
 
 def test_vector_apply_translation():


### PR DESCRIPTION
Closes: https://github.com/pygfx/pylinalg/issues/17

This PR implements `vector_from_matrix_position` and adds a pb test to ensure that it extracts the right components.