### PR TITLE
implement vector_euclidean_to_spherical

### DIFF
--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -289,11 +289,10 @@ def vector_euclidean_to_spherical(euclidean, /, *, out=None, dtype=None):
     out[..., 0] = np.sqrt(np.sum(euclidean**2, axis=-1))
 
     # choose phi = 0 if vector runs along y-axis
-    xz_zero = np.all(euclidean[..., [0, 2]] == 0, axis=-1)
-    out[..., 1] = np.divide(
-        -euclidean[..., 2], np.sqrt(np.sum(euclidean[..., [0, 2]] ** 2)), where=xz_zero
-    )
-    out[..., 1] = np.sign(-euclidean[..., 0]) * np.arccos(out[..., 1], where=xz_zero)
+    len_xz = np.sum(euclidean[..., [0, 2]] ** 2, axis=-1)
+    xz_nonzero = ~np.all(len_xz == 0, axis=-1)
+    out[..., 1] = np.divide(euclidean[..., 2], np.sqrt(len_xz), where=xz_nonzero)
+    out[..., 1] = np.sign(euclidean[..., 0]) * np.arccos(out[..., 1], where=xz_nonzero)
 
     # choose psi = 0 at the origin (0, 0, 0)
     r_zero = np.all(out[..., [0]] == 0, axis=-1)

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -295,9 +295,9 @@ def vector_euclidean_to_spherical(euclidean, /, *, out=None, dtype=None):
     out[..., 1] = np.sign(euclidean[..., 0]) * np.arccos(out[..., 1], where=xz_nonzero)
 
     # choose psi = 0 at the origin (0, 0, 0)
-    r_zero = np.all(out[..., [0]] == 0, axis=-1)
-    out[..., 2] = np.divide(euclidean[..., 2], out[..., 0], where=~r_zero)
-    out[..., 2] = np.arccos(out[..., 2], where=~r_zero)
+    r_nonzero = np.all(out[..., [0]] == 0, axis=-1)
+    out[..., 2] = np.divide(euclidean[..., 2], out[..., 0], where=r_nonzero)
+    out[..., 2] = np.arccos(out[..., 2], where=r_nonzero)
 
     return out
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,10 @@ def generate_spherical_vector(
     draw,
     radius=st.floats(min_value=0, max_value=360, allow_infinity=False, allow_nan=False),
     theta=st.floats(
-        min_value=0, max_value=np.pi, allow_infinity=False, allow_nan=False
+        min_value=EPS, max_value=np.pi - EPS, allow_infinity=False, allow_nan=False
     ),
     phi=st.floats(
-        min_value=0, max_value=2 * np.pi, allow_infinity=False, allow_nan=False
+        min_value=EPS, max_value=2 * np.pi - EPS, allow_infinity=False, allow_nan=False
     ),
 ):
     return np.array((draw(radius), draw(theta), draw(phi)))

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -1,8 +1,11 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
+from hypothesis import given
 
 import pylinalg as pla
+
+from .. import conftest as ct
 
 
 def test_vector_normalize():
@@ -62,6 +65,13 @@ def test_vector_apply_matrix_out():
     result = pla.vector_apply_matrix(vectors, matrix, out=out)
 
     assert result is out
+
+
+@given(ct.test_vector)
+def test_vector_euclidean_to_spherical(vector):
+    # result = pla.vector_euclidean_to_spherical(vector)
+
+    raise NotImplementedError("Waiting for upstream PR.")
 
 
 def test_vector_apply_matrix_out_performant():

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -1,7 +1,8 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
-from hypothesis import assume, given
+from hypothesis import assume, example, given
+from hypothesis.strategies import none
 
 import pylinalg as pla
 
@@ -83,11 +84,22 @@ def test_vector_apply_matrix_out():
     assert result is out
 
 
-@given(ct.test_vector)
-def test_vector_euclidean_to_spherical(vector):
-    # result = pla.vector_euclidean_to_spherical(vector)
+@given(ct.test_spherical, none())
+@example((1, 0, np.pi / 2), (0, 0, 1))
+@example((1, np.pi / 2, np.pi / 2), (1, 0, 0))
+@example((1, 0, 0), (0, 1, 0))
+def test_vector_euclidean_to_spherical(expected, vector):
+    if vector is None:
+        assume(abs(expected[0]) > 1e-6)
+        vector = pla.vector_spherical_to_euclidean(expected)
+    else:
+        expected = np.asarray(expected)
+        vector = np.asarray(vector)
 
-    raise NotImplementedError("Waiting for upstream PR.")
+    actual = pla.vector_euclidean_to_spherical(vector)
+
+    eps = max(3 * np.spacing(max(abs(expected))), 1e-6)
+    assert np.allclose(actual, expected, rtol=eps, atol=1e-6)
 
 
 def test_vector_apply_matrix_out_performant():

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -90,7 +90,7 @@ def test_vector_apply_matrix_out():
 @example((1, 0, 0), (0, 1, 0))
 def test_vector_euclidean_to_spherical(expected, vector):
     if vector is None:
-        assume(abs(expected[0]) > 1e-6)
+        assume(abs(expected[0]) > 1e-10)
         vector = pla.vector_spherical_to_euclidean(expected)
     else:
         expected = np.asarray(expected)
@@ -98,8 +98,7 @@ def test_vector_euclidean_to_spherical(expected, vector):
 
     actual = pla.vector_euclidean_to_spherical(vector)
 
-    eps = max(3 * np.spacing(max(abs(expected))), 1e-6)
-    assert np.allclose(actual, expected, rtol=eps, atol=1e-6)
+    assert np.allclose(actual, expected, rtol=1e-10)
 
 
 def test_vector_apply_matrix_out_performant():


### PR DESCRIPTION
Closes: https://github.com/pygfx/pylinalg/issues/14

This PR implements `euclidean -> spherical` space transformation. It also adds a pb test; however, this will have to wait until https://github.com/pygfx/pylinalg/pull/35 is merged, because then we can add a round-trip test to ensure that the conversion does what we think it does.