### PR TITLE
Add quaternion make from euler angles

### DIFF
--- a/pylinalg/func/matrix.py
+++ b/pylinalg/func/matrix.py
@@ -153,6 +153,8 @@ def matrix_make_rotation_from_euler_angles(
         axis_idx = {"x": 0, "y": 1, "z": 2}[axis]
 
         matrix = np.array([[cos(angle), -sin(angle)], [sin(angle), cos(angle)]])
+        if axis_idx == 1:
+            matrix = matrix.T
         matrix = np.insert(matrix, axis_idx, 0, axis=0)
         matrix = np.insert(matrix, axis_idx, 0, axis=1)
         matrix[axis_idx, axis_idx] = 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,10 +143,12 @@ def rotation_matrix(axis, angle):
         The angle to rotate by (in rad).
 
     """
+    axis_idx = {"x": 0, "y": 1, "z": 2}[axis]
 
     matrix = np.array([[cos(angle), -sin(angle)], [sin(angle), cos(angle)]])
+    if axis_idx == 1:
+        matrix = matrix.T
 
-    axis_idx = {"x": 0, "y": 1, "z": 2}[axis]
     matrix = np.insert(matrix, axis_idx, 0, axis=0)
     matrix = np.insert(matrix, axis_idx, 0, axis=1)
     matrix[axis_idx, axis_idx] = 1

--- a/tests/func/test_matrix.py
+++ b/tests/func/test_matrix.py
@@ -89,24 +89,24 @@ def test_matrix_make_rotation_from_axis_angle_xy():
         # case a
         ([0, 0, np.pi / 2], [0, 0, np.sqrt(2) / 2, np.sqrt(2) / 2], "f8"),
         # case a, two ordered rotations
-        ([0, np.pi / 2, np.pi / 2], [0.5, -0.5, 0.5, 0.5], "f8"),
+        ([0, -np.pi / 2, np.pi / 2], [0.5, -0.5, 0.5, 0.5], "f8"),
         # non-default dtype
-        ([0, np.pi / 2, np.pi / 2], [0.5, -0.5, 0.5, 0.5], "f4"),
+        ([0, -np.pi / 2, np.pi / 2], [0.5, -0.5, 0.5, 0.5], "f4"),
         # case b (contrived example for code coverage)
         (
-            [0, -np.pi * 0.51, np.pi * 0.51],
+            [0, np.pi * 0.51, np.pi * 0.51],
             [0.515705, -0.499753, -0.499753, -0.484295],
             "f8",
         ),
         # case c (contrived example for code coverage)
         (
-            [np.pi * 1.2, -np.pi * 1.8, np.pi],
+            [np.pi * 1.2, np.pi * 1.8, np.pi],
             [-0.095492, 0.904508, -0.293893, -0.293893],
             "f8",
         ),
         # case d (contrived example for code coverage)
         (
-            [np.pi * 0.45, -np.pi * 1.8, np.pi],
+            [np.pi * 0.45, np.pi * 1.8, np.pi],
             [0.234978, 0.617662, 0.723189, -0.20069],
             "f8",
         ),
@@ -128,7 +128,7 @@ def test_matrix_combine():
     # non-uniform scaling such that the test would fail if rotation/scaling are
     # applied in the incorrect order
     scaling = la.matrix_make_scaling([1, 2, 1])
-    rotation = la.matrix_make_rotation_from_euler_angles([0, -np.pi / 4, np.pi / 2])
+    rotation = la.matrix_make_rotation_from_euler_angles([0, np.pi / 4, np.pi / 2])
     translation = la.matrix_make_translation(2)
     # apply the standard SRT ordering
     result = la.matrix_combine([translation, rotation, scaling])

--- a/tests/func/test_quaternion.py
+++ b/tests/func/test_quaternion.py
@@ -2,10 +2,11 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 from hypothesis import given
+from hypothesis.strategies import text
 
 import pylinalg as la
 
-from ..conftest import test_quaternion, test_unit_vector
+from .. import conftest as ct
 
 
 @pytest.mark.parametrize(
@@ -112,7 +113,7 @@ def test_quaternion_from_axis_angle():
     npt.assert_array_almost_equal(q, [np.sqrt(2) / 2, 0, 0, np.sqrt(2) / 2])
 
 
-@given(test_unit_vector, test_quaternion)
+@given(ct.test_unit_vector, ct.test_quaternion)
 def test_quaternion_vs_matrix_rotate(vector, quaternion):
     matrix = la.quaternion_to_matrix(quaternion)
     hom_vector = np.ones(4, dtype=vector.dtype)
@@ -124,7 +125,7 @@ def test_quaternion_vs_matrix_rotate(vector, quaternion):
     npt.assert_array_almost_equal(actual, expected)
 
 
-@given(test_unit_vector, test_quaternion)
+@given(ct.test_unit_vector, ct.test_quaternion)
 def test_quaternion_rotate_inversion(vector, quaternion):
     inverse = la.quaternion_inverse(quaternion)
 
@@ -135,3 +136,13 @@ def test_quaternion_rotate_inversion(vector, quaternion):
     tmp = la.quaternion_rotate(vector, inverse)
     result = la.quaternion_rotate(tmp, quaternion)
     npt.assert_array_almost_equal(result, vector)
+
+
+@given(ct.test_angles_rad, text("xyz", min_size=1, max_size=3))
+def test_quaternion_make_from_euler_angles(angles, order):
+    angles = angles[: len(order)]
+    result = la.quaternion_make_from_euler_angles(angles, order=order)
+    actual = la.quaternion_to_matrix(result)
+
+    expected = la.matrix_make_rotation_from_euler_angles(angles, order=order)
+    assert np.allclose(actual, expected)

--- a/tests/func/test_quaternion.py
+++ b/tests/func/test_quaternion.py
@@ -15,24 +15,24 @@ from .. import conftest as ct
         # case a
         ([0, 0, np.pi / 2], [0, 0, np.sqrt(2) / 2, np.sqrt(2) / 2], "f8"),
         # case a, two ordered rotations
-        ([0, np.pi / 2, np.pi / 2], [0.5, -0.5, 0.5, 0.5], "f8"),
+        ([0, -np.pi / 2, np.pi / 2], [0.5, -0.5, 0.5, 0.5], "f8"),
         # non-default dtype
-        ([0, np.pi / 2, np.pi / 2], [0.5, -0.5, 0.5, 0.5], "f4"),
+        ([0, -np.pi / 2, np.pi / 2], [0.5, -0.5, 0.5, 0.5], "f4"),
         # case b (contrived example for code coverage)
         (
-            [0, -np.pi * 0.51, np.pi * 0.51],
+            [0, np.pi * 0.51, np.pi * 0.51],
             [0.515705, -0.499753, -0.499753, -0.484295],
             "f8",
         ),
         # case c (contrived example for code coverage)
         (
-            [np.pi * 1.2, -np.pi * 1.8, np.pi],
+            [np.pi * 1.2, np.pi * 1.8, np.pi],
             [-0.095492, 0.904508, -0.293893, -0.293893],
             "f8",
         ),
         # case d (contrived example for code coverage)
         (
-            [np.pi * 0.45, -np.pi * 1.8, np.pi],
+            [np.pi * 0.45, np.pi * 1.8, np.pi],
             [0.234978, 0.617662, 0.723189, -0.20069],
             "f8",
         ),

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -262,7 +262,7 @@ def test_vector_apply_rotation_ordered():
         [0, 1, 0],
     )
     matrix = la.matrix_make_rotation_from_euler_angles(
-        [0, -np.pi / 2, np.pi / 2], order="zyx"
+        [0, np.pi / 2, np.pi / 2], order="zyx"
     )
     result = la.vector_apply_matrix(vectors, matrix)
 


### PR DESCRIPTION
When I started porting pygfx yesterday I noticed we are missing the equivalent of `gfx.linalg.Quaternion().set_from_euler(...)`, which is used almost everywhere. (It's the thing that makes our examples rotate)

This PR adds this function under the name `quaternion_make_from_euler_angles`.

While implementing the tests, I've also found a bug that crept into some of the other functions related to rotation around cardinal axes: We rotate CCW around X and Z, but CW around Y. There is one function in our API that uses Euler angles: `matrix_make_rotation_from_euler_angles`, and after updating it to rotate CCW around Y, as per our conventions, a number of tests broke.

This leaves us with a choice: (1) We can update everything to rotate CCW around Y, or we can stick with rotating CW and document this difference. I prefer option (1), but can be flexible depending on how you guys think @Korijn @almarklein 