### PR TITLE
remove quaternion_rotate

### DIFF
--- a/pylinalg/func/quaternion.py
+++ b/pylinalg/func/quaternion.py
@@ -1,6 +1,10 @@
 """Note that we assume unit quaternions for faster implementations"""
 
+import warnings
+
 import numpy as np
+
+from .vector import vector_apply_quaternion_rotation
 
 
 def quaternion_to_matrix(quaternion, /, *, out=None, dtype=None):
@@ -231,18 +235,11 @@ def quaternion_rotate(vector, quaternion, /, *, out=None, dtype=None):
 
     """
 
-    vector = np.asarray(vector, dtype=dtype)
-    quaternion = np.asarray(quaternion, dtype=dtype)
-
-    scalar = quaternion[..., -1]
-    q_vector = quaternion[..., :3]
-
-    # the required linalg products
-    q_v = np.tensordot(q_vector, vector, axes=(-1, -1))
-    q_q = np.tensordot(q_vector, q_vector, axes=(-1, -1))
-    qxv = np.cross(q_vector, vector, axis=-1)
-
-    return (2 * q_v * q_vector) + (scalar**2 - q_q) * vector + 2 * scalar * qxv
+    warnings.warn(
+        "`quaternion_rotate` is deprecated. "
+        "Use `vector_apply_quaternion_rotation` instead."
+    )
+    return vector_apply_quaternion_rotation(vector, quaternion, out=out, dtype=dtype)
 
 
 def quaternion_make_from_euler_angles(angles, /, *, order="XYZ", out=None, dtype=None):

--- a/pylinalg/func/quaternion.py
+++ b/pylinalg/func/quaternion.py
@@ -1,10 +1,6 @@
 """Note that we assume unit quaternions for faster implementations"""
 
-import warnings
-
 import numpy as np
-
-from .vector import vector_apply_quaternion_rotation
 
 
 def quaternion_to_matrix(quaternion, /, *, out=None, dtype=None):
@@ -203,43 +199,6 @@ def quaternion_make_from_axis_angle(axis, angle, /, *, out=None, dtype=None):
     out[3] = np.cos(angle_half)
 
     return out
-
-
-def quaternion_rotate(vector, quaternion, /, *, out=None, dtype=None):
-    """
-    Rotate a vector using a quaternion.
-
-    Parameters
-    ----------
-    vector : ndarray, [3]
-        The vector to rotate in local space.
-    quaternion : ndarray, [4]
-        The quaternion to rotate by in ``(x, y, z, w)`` format.
-    out : ndarray, optional
-        A location into which the result is stored. If provided, it
-        must have a shape that the inputs broadcast to. If not provided or
-        None, a freshly-allocated array is returned. A tuple must have
-        length equal to the number of outputs.
-    dtype : data-type, optional
-        Overrides the data type of the result.
-
-    Returns
-    -------
-    rotated_vector : ndarray, [3]
-        The input vector rotated by the given quaternion.
-
-    Notes
-    -----
-    For improved accuracy consider normalizing the vector before applying the
-    rotation and then re-apply the original scale afterwards.
-
-    """
-
-    warnings.warn(
-        "`quaternion_rotate` is deprecated. "
-        "Use `vector_apply_quaternion_rotation` instead."
-    )
-    return vector_apply_quaternion_rotation(vector, quaternion, out=out, dtype=dtype)
 
 
 def quaternion_make_from_euler_angles(angles, /, *, order="XYZ", out=None, dtype=None):

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -170,7 +170,7 @@ def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
     return out
 
 
-def vector_apply_quaternion_rotation(vector, quaternion, /, *, out=None, dtype=None):
+def vector_apply_quaternion(vector, quaternion, /, *, out=None, dtype=None):
     """Rotate a vector using a quaternion.
 
     Parameters

--- a/tests/func/test_quaternion.py
+++ b/tests/func/test_quaternion.py
@@ -113,31 +113,6 @@ def test_quaternion_from_axis_angle():
     npt.assert_array_almost_equal(q, [np.sqrt(2) / 2, 0, 0, np.sqrt(2) / 2])
 
 
-@given(ct.test_unit_vector, ct.test_quaternion)
-def test_quaternion_vs_matrix_rotate(vector, quaternion):
-    matrix = la.quaternion_to_matrix(quaternion)
-    hom_vector = np.ones(4, dtype=vector.dtype)
-    hom_vector[:3] = vector
-
-    expected = (matrix @ hom_vector)[:3]
-    actual = la.quaternion_rotate(vector, quaternion)
-
-    npt.assert_array_almost_equal(actual, expected)
-
-
-@given(ct.test_unit_vector, ct.test_quaternion)
-def test_quaternion_rotate_inversion(vector, quaternion):
-    inverse = la.quaternion_inverse(quaternion)
-
-    tmp = la.quaternion_rotate(vector, quaternion)
-    result = la.quaternion_rotate(tmp, inverse)
-    npt.assert_array_almost_equal(result, vector)
-
-    tmp = la.quaternion_rotate(vector, inverse)
-    result = la.quaternion_rotate(tmp, quaternion)
-    npt.assert_array_almost_equal(result, vector)
-
-
 @given(ct.test_angles_rad, text("xyz", min_size=1, max_size=3))
 def test_quaternion_make_from_euler_angles(angles, order):
     angles = angles[: len(order)]

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -281,12 +281,12 @@ def test_vector_apply_rotation_ordered():
 
 
 @given(ct.test_vector, ct.test_quaternion)
-def test_vector_apply_quaternion_rotation(vector, quaternion):
+def test_vector_apply_quaternion(vector, quaternion):
     scale = np.linalg.norm(vector)
     if scale > 1e100:
         vector = vector / scale * 1e100
 
-    actual = la.vector_apply_quaternion_rotation(vector, quaternion)
+    actual = la.vector_apply_quaternion(vector, quaternion)
 
     # reference implementation
     matrix = la.quaternion_to_matrix(quaternion)
@@ -298,14 +298,14 @@ def test_vector_apply_quaternion_rotation(vector, quaternion):
 
 
 @given(ct.test_vector, ct.test_quaternion)
-def test_vector_apply_quaternion_rotation_identity(vector, quaternion):
+def test_vector_apply_quaternion_identity(vector, quaternion):
     scale = np.linalg.norm(vector)
     if scale > 1e100:
         vector = vector / scale * 1e100
 
     inv_quaternion = la.quaternion_inverse(quaternion)
-    tmp = la.vector_apply_quaternion_rotation(vector, quaternion)
-    actual = la.vector_apply_quaternion_rotation(tmp, inv_quaternion)
+    tmp = la.vector_apply_quaternion(vector, quaternion)
+    actual = la.vector_apply_quaternion(tmp, inv_quaternion)
 
     # assert relative proximity only
     assert np.allclose(actual, vector, rtol=1e-10, atol=np.inf)


### PR DESCRIPTION
Closes: https://github.com/pygfx/pylinalg/issues/52

This PR deprecates `quaternion_rotate` in favor of `vector_apply_quaternion_rotation`. It replaces `quaternion_rotate` with a call to `vector_apply_quaternion_rotation` and a deprecation notice.

@Korijn Do we want to rename `vector_apply_quaternion_rotation` to `vector_apply_quaternion` and save a few characters in the already long function name?