### PR TITLE
make vector_apply_matrix broadcast inputs

### DIFF
--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -95,9 +95,9 @@ def vector_apply_matrix(vectors, matrix, /, *, w=1, out=None, dtype=None):
         transformed vectors
     """
 
-    vectors = np.asarray(vectors, dtype=float)    
+    vectors = np.asarray(vectors, dtype=float)
     matrix = np.asarray(matrix, dtype=float)
-    
+
     if out is None:
         out_shape = np.broadcast_shapes(vectors.shape[:-1], matrix.shape[:-2])
         out = np.empty((*out_shape, 3), dtype=dtype)
@@ -108,6 +108,7 @@ def vector_apply_matrix(vectors, matrix, /, *, w=1, out=None, dtype=None):
     out[:] = result[..., :-1, 0]
 
     return out
+
 
 def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
     """

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -99,7 +99,8 @@ def vector_apply_matrix(vectors, matrix, /, *, w=1, out=None, dtype=None):
     matrix = np.asarray(matrix, dtype=float)
     
     if out is None:
-        out = np.empty(vectors.shape, dtype=dtype)
+        out_shape = np.broadcast_shapes(vectors.shape[:-1], matrix.shape[:-2])
+        out = np.empty((*out_shape, 3), dtype=dtype)
 
     vectors = vector_make_homogeneous(vectors, w=w)
     result = matrix @ vectors[..., None]


### PR DESCRIPTION
While porting pygfx I noticed that `vector_apply_matrix` can handle batches of vectors, but doesn't use broadcasting to do so limiting us to a single matrix. This PR rewrites the function to allow broadcasting of inputs (adhering to our convention that the last axes are core dimensions and everything else is a loop dimension).