### PR TITLE
allow broadcasting of simple rotations

### DIFF
--- a/pylinalg/func/matrix.py
+++ b/pylinalg/func/matrix.py
@@ -146,7 +146,12 @@ def matrix_make_rotation_from_euler_angles(
     ccw around the y-axis, and finally 0° around the x axis.
 
     """
+    angles = np.asarray(angles, dtype=float)
     order = order.lower()
+
+    if angles.ndim == 0:
+        # add dimension to allow zip
+        angles = angles[None]
 
     matrices = []
     for angle, axis in zip(angles, order):

--- a/pylinalg/func/quaternion.py
+++ b/pylinalg/func/quaternion.py
@@ -228,7 +228,7 @@ def quaternion_make_from_euler_angles(angles, /, *, order="XYZ", out=None, dtype
     """
 
     angles = np.asarray(angles, dtype=float)
-    batch_shape = angles.shape[:-1]
+    batch_shape = angles.shape[:-1] if len(order) > 1 else angles.shape
 
     if out is None:
         out = np.empty((*batch_shape, 4), dtype=dtype)

--- a/tests/func/test_quaternion.py
+++ b/tests/func/test_quaternion.py
@@ -115,7 +115,7 @@ def test_quaternion_from_axis_angle():
 
 @given(ct.test_angles_rad, text("xyz", min_size=1, max_size=3))
 def test_quaternion_make_from_euler_angles(angles, order):
-    angles = angles[: len(order)]
+    angles = np.squeeze(angles[: len(order)])
     result = la.quaternion_make_from_euler_angles(angles, order=order)
     actual = la.quaternion_to_matrix(result)
 


### PR DESCRIPTION
I noticed a bug in `la.quaternion_make_from_euler_angles`. If the user supplies a batch of `angles` but only rotates around a single axis (e.g. `order="x"`) then the current implementation produces an exception because it trips over the missing/implied core dimension of `angles`. This PR fixes that and makes batches of simple rotations behave like all the others.