### PR TITLE
(un)project along the z-axis

### DIFF
--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -163,7 +163,7 @@ def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
     vector_hom[..., [0, 1]] = vector
     vector_hom[..., 3] = 0
 
-    out[:] = (inverse_projection @ vector_hom)[..., :-1]
+    out[:] = (vector_hom @ inverse_projection.T)[..., :-1]
 
     return out
 

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -142,8 +142,8 @@ def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
 
     Notes
     -----
-    The source frame of this operation is the camera's local XY-plane and the target frame
-    is the camera's local frame.
+    The source frame of this operation is the camera's local XY-plane and the
+    target frame is the camera's local frame.
     """
 
     vector = np.asarray(vector, dtype=float)

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -139,6 +139,11 @@ def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
     -------
     projected_vector : ndarray, [3]
         The unprojected vector in 3D space
+
+    Notes
+    -----
+    The source frame of this operation is the camera's local XY-plane and the target frame
+    is the camera's local frame.
     """
 
     vector = np.asarray(vector, dtype=float)
@@ -154,8 +159,8 @@ def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
         raise ValueError("The provided matrix is not invertible.")
 
     vector_hom = np.empty((*vector.shape[:-1], 4), dtype=dtype)
-    vector_hom[..., 0] = depth
-    vector_hom[..., [1, 2]] = vector
+    vector_hom[..., 2] = depth
+    vector_hom[..., [0, 1]] = vector
     vector_hom[..., 3] = 0
 
     out[:] = (inverse_projection @ vector_hom)[..., :-1]

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -237,9 +237,12 @@ def test_vector_apply_rotation_about_z_matrix():
 
 
 @given(ct.test_vector, ct.test_projection)
+@example(
+    ((250, 250, 0), (-250, -250, 0)),
+    la.matrix_make_orthographic(250, -250, 250, -250, -100, 100, depth_range=(0, 1)),
+)
 def test_vector_unproject(expected, projection_matrix):
-    expected_hom = la.vector_make_homogeneous(expected)
-    expected_2d = projection_matrix @ expected_hom
+    expected_2d = la.vector_apply_matrix(expected, projection_matrix)
 
     depth = expected_2d[..., 2]
     vector = expected_2d[..., [0, 1]]

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -237,10 +237,6 @@ def test_vector_apply_rotation_about_z_matrix():
 
 
 @given(ct.test_vector, ct.test_projection)
-@example(
-    ((250, 250, 0), (-250, -250, 0)),
-    la.matrix_make_orthographic(250, -250, 250, -250, -100, 100, depth_range=(0, 1)),
-)
 def test_vector_unproject(expected, projection_matrix):
     expected_2d = la.vector_apply_matrix(expected, projection_matrix)
 
@@ -251,6 +247,15 @@ def test_vector_unproject(expected, projection_matrix):
 
     # only test stable results
     assume(not np.any(np.isnan(actual) | np.isinf(actual)))
+    assert np.allclose(actual, expected, rtol=1e-16, atol=np.inf)
+
+
+def test_unproject_explicitly():
+    matrix = la.matrix_make_orthographic(250, -250, 250, -250, -100, 100, depth_range=(0, 1))
+    expected = np.array(((250, 250, 0), (-250, -250, 0)))
+    projected = np.array(((1, 1), (-1, -1)))
+                         
+    actual = la.vector_unproject(projected, matrix)
     assert np.allclose(actual, expected, rtol=1e-16, atol=np.inf)
 
 

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -241,8 +241,8 @@ def test_vector_unproject(expected, projection_matrix):
     expected_hom = la.vector_make_homogeneous(expected)
     expected_2d = projection_matrix @ expected_hom
 
-    depth = expected_2d[..., 0]
-    vector = expected_2d[..., [1, 2]]
+    depth = expected_2d[..., 2]
+    vector = expected_2d[..., [0, 1]]
 
     actual = la.vector_unproject(vector, projection_matrix, depth=depth)
 

--- a/tests/func/test_vectors.py
+++ b/tests/func/test_vectors.py
@@ -251,10 +251,12 @@ def test_vector_unproject(expected, projection_matrix):
 
 
 def test_unproject_explicitly():
-    matrix = la.matrix_make_orthographic(250, -250, 250, -250, -100, 100, depth_range=(0, 1))
+    matrix = la.matrix_make_orthographic(
+        250, -250, 250, -250, -100, 100, depth_range=(0, 1)
+    )
     expected = np.array(((250, 250, 0), (-250, -250, 0)))
     projected = np.array(((1, 1), (-1, -1)))
-                         
+
     actual = la.vector_unproject(projected, matrix)
     assert np.allclose(actual, expected, rtol=1e-16, atol=np.inf)
 


### PR DESCRIPTION
I think I made a mistake when implementing the function to unproject. I don't remember the exact reason for why (I think it was at the time where we were discussing what exactly our frame conventions are), but unproject operates along the x-axis (first axis) instead of operating along the z-axis (third axis). This PR fixes that.