### PR TITLE
Use offset when unprojecting

### DIFF
--- a/pylinalg/func/matrix.py
+++ b/pylinalg/func/matrix.py
@@ -474,6 +474,16 @@ def matrix_make_orthographic(
     -------
     matrix : ndarray, [4, 4]
         orthographic projection matrix
+
+    Notes
+    -----
+    The parameters to this function are given in a left-handed frame that is
+    obtained by mirroring source's Z-axis at the origin. In other words, if the
+    returned matrix represents a camera's projection matrix then this function's
+    parameters are given in a frame that is like the camera's local frame except
+    that it's Z-axis is inverted. This means that positive values for `near` and
+    `far` refer to a negative Z values in camera local.
+
     """
 
     left = np.asarray(left, dtype=float)

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -142,8 +142,8 @@ def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
 
     Notes
     -----
-    The source frame of this operation is the camera's local XY-plane and the
-    target frame is the camera's local frame.
+    The source frame of this operation is the XY-plane of the camera's NDC frame
+    and the target frame is the camera's local frame.
     """
 
     vector = np.asarray(vector, dtype=float)
@@ -161,7 +161,7 @@ def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
     vector_hom = np.empty((*vector.shape[:-1], 4), dtype=dtype)
     vector_hom[..., 2] = depth
     vector_hom[..., [0, 1]] = vector
-    vector_hom[..., 3] = 0
+    vector_hom[..., 3] = 1
 
     out[:] = (vector_hom @ inverse_projection.T)[..., :-1]
 

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -163,7 +163,9 @@ def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
     vector_hom[..., [0, 1]] = vector
     vector_hom[..., 3] = 1
 
-    out[:] = (vector_hom @ inverse_projection.T)[..., :-1]
+    out_hom = vector_hom @ inverse_projection.T
+    scale = out_hom[..., -1][..., None]
+    out[:] = (out_hom / scale)[..., :-1]
 
     return out
 

--- a/pylinalg/func/vector.py
+++ b/pylinalg/func/vector.py
@@ -150,15 +150,19 @@ def vector_unproject(vector, matrix, /, *, depth=0, out=None, dtype=None):
     matrix = np.asarray(matrix, dtype=float)
     depth = np.asarray(depth, dtype=float)
 
+    result_shape = np.broadcast_shapes(
+        vector.shape[:-1], matrix.shape[:-2], depth.shape
+    )
+
     if out is None:
-        out = np.empty((*vector.shape[:-1], 3), dtype=dtype)
+        out = np.empty((*result_shape, 3), dtype=dtype)
 
     try:
         inverse_projection = np.linalg.inv(matrix)
     except np.linalg.LinAlgError:
         raise ValueError("The provided matrix is not invertible.")
 
-    vector_hom = np.empty((*vector.shape[:-1], 4), dtype=dtype)
+    vector_hom = np.empty((*result_shape, 4), dtype=dtype)
     vector_hom[..., 2] = depth
     vector_hom[..., [0, 1]] = vector
     vector_hom[..., 3] = 1


### PR DESCRIPTION
Another bug in unproject ... when we use an asymmetric `depth_range` then we need to apply the position of the transformation matrix. Previously, we have ignored it.

@almarklein I also noticed some surprising behavior for `matrix_make_orthogonal` in how it handles the far and near plane. Could you have a look at the comment and see what makes sense for us?