### PR TITLE
invert mapping returned by matrix_make_look_at

### DIFF
--- a/pylinalg/func/matrix.py
+++ b/pylinalg/func/matrix.py
@@ -604,15 +604,14 @@ def matrix_make_look_at(eye, target, up_reference, /, *, out=None, dtype=None):
     view = as_strided(out, shape=(n_matrices, 4), strides=(16 * itemsize, 5 * itemsize))
     view[:] = 1
 
-    # Note: building the inverse/transpose directly
-    out[..., 2, :-1] = new_z / np.linalg.norm(new_z, axis=-1)
-    out[..., 0, :-1] = np.cross(
-        up_reference, out[..., 2, :-1], axisa=-1, axisb=-1, axisc=-1
+    out[..., :-1, 2] = new_z / np.linalg.norm(new_z, axis=-1)
+    out[..., :-1, 0] = np.cross(
+        up_reference, out[..., :-1, 2], axisa=-1, axisb=-1, axisc=-1
     )
-    out[..., 1, :-1] = np.cross(
-        out[..., 2, :-1], out[..., 0, :-1], axisa=-1, axisb=-1, axisc=-1
+    out[..., :-1, 1] = np.cross(
+        out[..., :-1, 2], out[..., :-1, 0], axisa=-1, axisb=-1, axisc=-1
     )
-    out /= np.linalg.norm(out, axis=-1)[..., :, None]
+    out /= np.linalg.norm(out, axis=-2)[..., None, :]
 
     return out
 

--- a/tests/func/test_matrix.py
+++ b/tests/func/test_matrix.py
@@ -242,9 +242,10 @@ def test_matrix_make_look_at(eye, target, up_reference):
     target_pointer = target - eye
     target_pointer = target_pointer / np.linalg.norm(target_pointer)
     target_pointer = la.vector_make_homogeneous(target_pointer)
-    result = rotation @ target_pointer
-    assert np.allclose(result[:3], (0, 0, 1), rtol=1e-16)
+    result = rotation @ (0, 0, 1, 1)
+    assert np.allclose(result, target_pointer, rtol=1e-16)
 
     # ensure y_new, z_new, and up_reference roughly align
-    new_reference = rotation @ la.vector_make_homogeneous(up_reference)
+    # (map up_reference from target to source space and check if it's in the YZ-plane)
+    new_reference = rotation.T @ la.vector_make_homogeneous(up_reference)
     assert np.abs(new_reference[0]) < 1e-10


### PR DESCRIPTION
This PR inverts the rotation matrix returned by `matrix_make_look_at`. When I wrote this function originally I was under the impression that we will be using the convention that we left-multiply vectors (`vectors @ matrix`). However, pygfx right-multiplies vectors and as such returning the transposed/inverted matrix here is confusing and may cause bigs. This PR makes the behavior more consistent.