### PR TITLE
Fix quaternion from ax angle

### DIFF
--- a/pylinalg/func/quaternion.py
+++ b/pylinalg/func/quaternion.py
@@ -207,12 +207,19 @@ def quaternion_make_from_axis_angle(axis, angle, /, *, out=None, dtype=None):
         Quaternion.
     """
 
-    if out is None:
-        out = np.empty(4, dtype=dtype)
+    axis = np.asarray(axis, dtype=float)
+    angle = np.asarray(angle, dtype=float)
 
-    angle_half = angle / 2
-    out[:3] = np.asarray(axis) * np.sin(angle_half)
-    out[3] = np.cos(angle_half)
+    out_shape = np.broadcast_shapes(axis.shape[:-1], angle.shape)
+
+    if out is None:
+        out = np.empty((*out_shape, 4), dtype=dtype)
+
+    # result should be independent of the length of the given axis
+    axis /= np.linalg.norm(axis, axis=-1)
+
+    out[..., :3] = np.asarray(axis) * np.sin(angle / 2)
+    out[..., 3] = np.cos(angle / 2)
 
     return out
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,7 +245,7 @@ legal_numbers = from_dtype(
     min_value=-1e150,
     max_value=1e150,
 )
-legal_positive_numbers = from_dtype(
+legal_positive_number = from_dtype(
     np.dtype(float),
     allow_infinity=False,
     allow_nan=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,6 +245,13 @@ legal_numbers = from_dtype(
     min_value=-1e150,
     max_value=1e150,
 )
+legal_positive_numbers = from_dtype(
+    np.dtype(float),
+    allow_infinity=False,
+    allow_nan=False,
+    min_value=0,
+    max_value=1e150,
+)
 legal_angle = from_dtype(
     np.dtype(float),
     allow_infinity=False,

--- a/tests/func/test_quaternion.py
+++ b/tests/func/test_quaternion.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
-from hypothesis import given
+from hypothesis import given, assume
 from hypothesis.strategies import text
 
 import pylinalg as la
@@ -111,6 +111,25 @@ def test_quaternion_from_axis_angle():
     q = la.quaternion_make_from_axis_angle(axis, angle)
 
     npt.assert_array_almost_equal(q, [np.sqrt(2) / 2, 0, 0, np.sqrt(2) / 2])
+
+
+@given(ct.test_vector, ct.legal_angle)
+def test_quaternion_from_axis_angle2(true_axis, true_angle):
+    assume(np.linalg.norm(true_axis) > 1e-10)
+    assume(np.linalg.norm(true_axis) < 1e300)
+
+    assume(abs(true_angle) > 1e-8)
+    assume(abs(true_angle) < 2 * np.pi - 1e-8)
+
+    quaternion = la.quaternion_make_from_axis_angle(true_axis, true_angle)
+    axis, angle = la.axis_angle_from_quaternion(quaternion)
+
+    assert np.allclose(angle, true_angle)
+
+    # axis should (roughly) align
+    expected_dot = np.sum(true_axis**2)
+    actual_dot = np.dot(axis, true_axis)
+    assert np.allclose(actual_dot, expected_dot)
 
 
 @given(ct.test_angles_rad, text("xyz", min_size=1, max_size=3))

--- a/tests/func/test_quaternion.py
+++ b/tests/func/test_quaternion.py
@@ -105,18 +105,20 @@ def test_quaternion_inverse():
     npt.assert_array_equal(b[..., 3], bi[..., 3])
 
 
-def test_quaternion_from_axis_angle():
+@given(ct.legal_positive_numbers)
+def test_quaternion_from_axis_angle(length):
+    assume(abs(length) > 1e-10)
+
     axis = np.array([1, 0, 0], dtype="f4")
     angle = np.pi / 2
-    q = la.quaternion_make_from_axis_angle(axis, angle)
+    q = la.quaternion_make_from_axis_angle(length * axis, angle)
 
     npt.assert_array_almost_equal(q, [np.sqrt(2) / 2, 0, 0, np.sqrt(2) / 2])
 
 
 @given(ct.test_vector, ct.legal_angle)
-def test_quaternion_from_axis_angle2(true_axis, true_angle):
+def test_quaternion_from_axis_angle_roundtrip(true_axis, true_angle):
     assume(np.linalg.norm(true_axis) > 1e-10)
-    assume(np.linalg.norm(true_axis) < 1e300)
 
     assume(abs(true_angle) > 1e-8)
     assume(abs(true_angle) < 2 * np.pi - 1e-8)

--- a/tests/func/test_quaternion.py
+++ b/tests/func/test_quaternion.py
@@ -1,7 +1,7 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
-from hypothesis import given, assume
+from hypothesis import assume, given
 from hypothesis.strategies import text
 
 import pylinalg as la

--- a/tests/func/test_quaternion.py
+++ b/tests/func/test_quaternion.py
@@ -105,7 +105,7 @@ def test_quaternion_inverse():
     npt.assert_array_equal(b[..., 3], bi[..., 3])
 
 
-@given(ct.legal_positive_numbers)
+@given(ct.legal_positive_number)
 def test_quaternion_from_axis_angle(length):
     assume(abs(length) > 1e-10)
 
@@ -116,22 +116,24 @@ def test_quaternion_from_axis_angle(length):
     npt.assert_array_almost_equal(q, [np.sqrt(2) / 2, 0, 0, np.sqrt(2) / 2])
 
 
-@given(ct.test_vector, ct.legal_angle)
-def test_quaternion_from_axis_angle_roundtrip(true_axis, true_angle):
-    assume(np.linalg.norm(true_axis) > 1e-10)
+@given(ct.test_unit_vector, ct.legal_angle, ct.legal_positive_number)
+def test_quaternion_from_axis_angle_roundtrip(true_axis, true_angle, axis_scaling):
+    assume(abs(axis_scaling) > 1e-6)
 
-    assume(abs(true_angle) > 1e-8)
-    assume(abs(true_angle) < 2 * np.pi - 1e-8)
+    assume(abs(true_angle) > 1e-6)
+    assume(abs(true_angle) < 2 * np.pi - 1e-6)
 
-    quaternion = la.quaternion_make_from_axis_angle(true_axis, true_angle)
+    quaternion = la.quaternion_make_from_axis_angle(
+        axis_scaling * true_axis, true_angle
+    )
     axis, angle = la.axis_angle_from_quaternion(quaternion)
 
     assert np.allclose(angle, true_angle)
 
-    # axis should (roughly) align
-    expected_dot = np.sum(true_axis**2)
+    # Note: We loose the scaling of the axis, but can (roughly) reconstruct the
+    # direction
     actual_dot = np.dot(axis, true_axis)
-    assert np.allclose(actual_dot, expected_dot)
+    assert np.allclose(actual_dot, 1)
 
 
 @given(ct.test_angles_rad, text("xyz", min_size=1, max_size=3))


### PR DESCRIPTION
While working on the gizmo I realized that the axis passed to `quaternion_make_from_axis_angle` is not normalized when creating the rotation. As a result, the resulting quaternion isn't guaranteed to have unit length, meaning that we introduce a scaling alongside the rotation.

This PR:

1. Fixes this by normalizing the axis.
2. Upgrades the current unit test to test for various axis lengths.
3. Extends `quaternion_make_from_axis_angle` to allow broadcasting of inputs.
4. Adds `axis_angle_from_quaternion` to the `misc` module to convert quaternions back to axis-angle representation.
5. Adds a property-based test to ensure that we can convert from axis-angle to quaternion and back.