### PR TITLE
Add `scale` keyword argument to `mat_decompose`

### DIFF
--- a/pylinalg/matrix.py
+++ b/pylinalg/matrix.py
@@ -364,9 +364,7 @@ def mat_decompose(matrix, /, *, scaling_signs=None, dtype=None, out=None):
     else:
         # if not, detect if a flip is needed to reconstruct the transform
         # and apply it to the first axis arbitrarily
-        flip = 1
-        if np.linalg.det(matrix) < 0:
-            flip = -1
+        flip = 1 if np.linalg.det(matrix) >= 0 else -1
         scaling_signs = np.array([flip, 1, 1])
 
     if out is not None:

--- a/pylinalg/matrix.py
+++ b/pylinalg/matrix.py
@@ -319,7 +319,7 @@ def mat_compose(translation, rotation, scaling, /, *, out=None, dtype=None):
     )
 
 
-def mat_decompose(matrix, /, *, dtype=None, out=None):
+def mat_decompose(matrix, /, *, scaling=None, dtype=None, out=None):
     """
     Decompose a transformation matrix into a translation vector, a
     quaternion and a scaling vector.
@@ -328,6 +328,8 @@ def mat_decompose(matrix, /, *, dtype=None, out=None):
     ----------
     matrix : ndarray, [4, 4]
         transformation matrix
+    scaling : ndarray, [3], optional
+        scaling factors
     out : ndarray, optional
         A location into which the result is stored. If provided, it
         must have a shape that the inputs broadcast to. If not provided or
@@ -343,7 +345,7 @@ def mat_decompose(matrix, /, *, dtype=None, out=None):
     rotation : ndarray, [4]
         quaternion
     scaling : ndarray, [3]
-        scaling factor(s)
+        scaling factors
     """
     matrix = np.asarray(matrix)
 
@@ -353,13 +355,16 @@ def mat_decompose(matrix, /, *, dtype=None, out=None):
         translation = np.empty((3,), dtype=dtype)
     translation[:] = matrix[:-1, -1]
 
-    if out is not None:
-        scaling = out[2]
+    if scaling is not None:
+        scaling = np.asarray(scaling)
     else:
-        scaling = np.empty((3,), dtype=dtype)
-    scaling[:] = np.linalg.norm(matrix[:-1, :-1], axis=0)
-    if np.linalg.det(matrix) < 0:
-        scaling[0] *= -1
+        if out is not None:
+            scaling = out[2]
+        else:
+            scaling = np.empty((3,), dtype=dtype)
+        scaling[:] = np.linalg.norm(matrix[:-1, :-1], axis=0)
+        if np.linalg.det(matrix) < 0:
+            scaling[0] *= -1
 
     rotation = out[1] if out is not None else None
     rotation_matrix = matrix[:-1, :-1] * (1 / scaling)[None, :]

--- a/pylinalg/matrix.py
+++ b/pylinalg/matrix.py
@@ -329,7 +329,9 @@ def mat_decompose(matrix, /, *, scaling=None, dtype=None, out=None):
     matrix : ndarray, [4, 4]
         transformation matrix
     scaling : ndarray, [3], optional
-        scaling factors
+        scaling factors. If you wish to preserve the original scaling
+        factors through a compose-decompose roundtrip, you should
+        provide the original scaling factors.
     out : ndarray, optional
         A location into which the result is stored. If provided, it
         must have a shape that the inputs broadcast to. If not provided or

--- a/pylinalg/matrix.py
+++ b/pylinalg/matrix.py
@@ -358,13 +358,17 @@ def mat_decompose(matrix, /, *, scaling_signs=None, dtype=None, out=None):
         translation = np.empty((3,), dtype=dtype)
     translation[:] = matrix[:-1, -1]
 
+    flip = 1 if np.linalg.det(matrix) >= 0 else -1
     if scaling_signs is not None:
         # if the user provides the scaling signs, always use them
         scaling_signs = np.sign(scaling_signs)
+        if np.prod(scaling_signs) != flip:
+            raise ValueError(
+                "Number of negative signs is inconsistent with the determinant"
+            )
     else:
         # if not, detect if a flip is needed to reconstruct the transform
         # and apply it to the first axis arbitrarily
-        flip = 1 if np.linalg.det(matrix) >= 0 else -1
         scaling_signs = np.array([flip, 1, 1])
 
     if out is not None:

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -240,6 +240,18 @@ def test_mat_compose_roundtrip(signs):
     npt.assert_array_almost_equal(rotation, rotation3)
 
 
+def test_mat_compose_validation():
+    """Test that decompose validates consistency of scaling signs."""
+    signs = [-1, -1, -1]
+    scaling = np.array([1, 2, -3]) * signs
+    rotation = [0, 0, np.sqrt(2) / 2, np.sqrt(2) / 2]
+    translation = [-100, -6, 5]
+    matrix = la.mat_compose(translation, rotation, scaling)
+
+    with pytest.raises(ValueError):
+        la.mat_decompose(matrix, scaling_signs=signs)
+
+
 def test_mat_perspective():
     a = la.mat_perspective(-1, 1, -1, 1, 1, 100)
     npt.assert_array_almost_equal(

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -192,6 +192,34 @@ def test_mat_decompose():
     npt.assert_array_almost_equal(rotation, [0, 0, np.sqrt(2) / 2, np.sqrt(2) / 2])
 
 
+def test_mat_compose_roundtrip():
+    """Test that transform components survive a matrix
+    compose -> decompose roundtrip."""
+    scaling = [1, 2, -3]
+    # quaternion corresponding to 90 degree rotation about z-axis
+    rotation = [0, 0, np.sqrt(2) / 2, np.sqrt(2) / 2]
+    translation = [-100, -6, 5]
+    matrix = la.mat_compose(translation, rotation, scaling)
+    npt.assert_array_almost_equal(
+        matrix,
+        [
+            [0, -2, 0, -100],
+            [1, 0, 0, -6],
+            [0, 0, -3, 5],
+            [0, 0, 0, 1],
+        ],
+    )
+
+    # decompose cannot reconstruct original scaling
+    # so this is expected to fail
+    translation2, rotation2, scaling2 = la.mat_decompose(matrix)
+    npt.assert_array_equal(translation, translation2)
+    with pytest.raises(AssertionError):
+        npt.assert_array_equal(scaling, scaling2)
+    with pytest.raises(AssertionError):
+        npt.assert_array_equal(rotation, rotation2)
+
+
 def test_mat_perspective():
     a = la.mat_perspective(-1, 1, -1, 1, 1, 100)
     npt.assert_array_almost_equal(

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -219,6 +219,12 @@ def test_mat_compose_roundtrip():
     with pytest.raises(AssertionError):
         npt.assert_array_equal(rotation, rotation2)
 
+    # now inform decompose of the original scaling
+    translation3, rotation3, scaling3 = la.mat_decompose(matrix, scaling=scaling)
+    npt.assert_array_equal(translation, translation3)
+    npt.assert_array_equal(scaling, scaling3)
+    npt.assert_array_almost_equal(rotation, rotation3)
+
 
 def test_mat_perspective():
     a = la.mat_perspective(-1, 1, -1, 1, 1, 100)


### PR DESCRIPTION
Closes #81 

- [x] Add test exemplifying problematic roundtrip
- [x] Add `scale` keyword argument to `mat_decompose`