### PR TITLE
fix decompose when scaling is 0

### DIFF
--- a/pylinalg/matrix.py
+++ b/pylinalg/matrix.py
@@ -379,7 +379,11 @@ def mat_decompose(matrix, /, *, scaling_signs=None, dtype=None, out=None):
     scaling *= scaling_signs
 
     rotation = out[1] if out is not None else None
-    rotation_matrix = matrix[:-1, :-1] * (1 / scaling)[None, :]
+
+    rotation_matrix = matrix[:-1, :-1].copy()
+    mask = scaling != 0
+    rotation_matrix[:, mask] /= scaling[mask][None, :]
+    rotation_matrix[:, ~mask] = 0.0 
     rotation = quat_from_mat(rotation_matrix, out=rotation, dtype=dtype)
 
     return translation, rotation, scaling

--- a/pylinalg/matrix.py
+++ b/pylinalg/matrix.py
@@ -383,7 +383,7 @@ def mat_decompose(matrix, /, *, scaling_signs=None, dtype=None, out=None):
     rotation_matrix = matrix[:-1, :-1].copy().astype(float)
     mask = scaling != 0
     rotation_matrix[:, mask] /= scaling[mask][None, :]
-    rotation_matrix[:, ~mask] = 0.0 
+    rotation_matrix[:, ~mask] = 0.0
     rotation = quat_from_mat(rotation_matrix, out=rotation, dtype=dtype)
 
     return translation, rotation, scaling

--- a/pylinalg/matrix.py
+++ b/pylinalg/matrix.py
@@ -380,7 +380,7 @@ def mat_decompose(matrix, /, *, scaling_signs=None, dtype=None, out=None):
 
     rotation = out[1] if out is not None else None
 
-    rotation_matrix = matrix[:-1, :-1].copy()
+    rotation_matrix = matrix[:-1, :-1].copy().astype(float)
     mask = scaling != 0
     rotation_matrix[:, mask] /= scaling[mask][None, :]
     rotation_matrix[:, ~mask] = 0.0 

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -192,6 +192,21 @@ def test_mat_decompose():
     npt.assert_array_almost_equal(rotation, [0, 0, np.sqrt(2) / 2, np.sqrt(2) / 2])
 
 
+def test_mat_decompose_scaling_0():
+    """Test that the matrices are decomposed correctly when scaling is 0."""
+
+    scaling = [0, 0, 2]
+    rotation = [0, 0, np.sqrt(2) / 2, np.sqrt(2) / 2]
+    translation = [2, 2, 2]
+
+    matrix = la.mat_compose(translation, rotation, scaling)
+    translation_, rotation_, scaling_ = la.mat_decompose(matrix)
+
+    npt.assert_array_almost_equal(translation_, translation)
+    npt.assert_array_almost_equal(scaling_, scaling)
+    # rotation is not uniquely defined when scaling is 0, but it should not be NaN
+    assert not np.isnan(rotation_).any()
+
 @pytest.mark.parametrize(
     "signs",
     [

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -207,6 +207,7 @@ def test_mat_decompose_scaling_0():
     # rotation is not uniquely defined when scaling is 0, but it should not be NaN
     assert not np.isnan(rotation_).any()
 
+
 @pytest.mark.parametrize(
     "signs",
     [


### PR DESCRIPTION
When performing matrix decomposition, if any scaling factor is zero, a division by zero exception occurs, leading to NaN values in the matrix. This causes subsequent SVD computations to fail.

When the scaling factor along a certain axis is zero, the rotation along that axis becomes meaningless. In this case, the rotational component along that axis should be ignored, and the corresponding column in the rotation matrix (representing that axis' rotation) should be set to zero.

See: [Interpolation Test](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/InterpolationTest/README.md)  case in https://github.com/pygfx/pygfx/issues/910