### PR TITLE
Various improvements

### DIFF
--- a/pylinalg/matrix.py
+++ b/pylinalg/matrix.py
@@ -737,8 +737,7 @@ def _mat_inv(m) -> np.ndarray:
     det = n11 * t11 + n21 * t12 + n31 * t13 + n41 * t14
 
     if det == 0:
-        out.fill(0)
-        return out  # singular matrix
+        raise np.linalg.LinAlgError("Singular matrix")
 
     det_inv = 1 / det
 
@@ -857,7 +856,7 @@ else:
 
 
 def mat_inverse(
-    matrix, /, *, method=_default_mat_inv_method, dtype=None, out=None
+    matrix, /, *, method=_default_mat_inv_method, raise_err=False, dtype=None, out=None
 ) -> np.ndarray:
     """
     Compute the inverse of a matrix.
@@ -869,6 +868,8 @@ def mat_inverse(
     method : str, optional
         The method to use for inversion. The default is "numpy" when
         numpy version is 2.0.0 or newer, otherwise "python".
+    raise_err : bool, optional
+        Raise a ValueError if the matrix is singular. Default is False.
     dtype : data-type, optional
         Overrides the data type of the result.
     out : ndarray, optional
@@ -905,7 +906,9 @@ def mat_inverse(
     matrix = np.asarray(matrix)
     try:
         inverse = fn(matrix)
-    except np.linalg.LinAlgError:
+    except np.linalg.LinAlgError as err:
+        if raise_err:
+            raise ValueError("The provided matrix is not invertible.") from err
         inverse = np.zeros_like(matrix, dtype=dtype)
     if out is None:
         return np.asarray(inverse, dtype=dtype)

--- a/pylinalg/matrix.py
+++ b/pylinalg/matrix.py
@@ -853,7 +853,7 @@ def _mat_inv(m) -> np.ndarray:
 if int(np.__version__.split(".")[0]) >= 2:
     _default_mat_inv_method = "numpy"
 else:
-    _default_mat_inv_method = "manual"
+    _default_mat_inv_method = "python"
 
 
 def mat_inverse(
@@ -868,7 +868,7 @@ def mat_inverse(
         The matrix to invert.
     method : str, optional
         The method to use for inversion. The default is "numpy" when
-        numpy version is 2.0.0 or newer, otherwise "manual".
+        numpy version is 2.0.0 or newer, otherwise "python".
     dtype : data-type, optional
         Overrides the data type of the result.
     out : ndarray, optional
@@ -886,11 +886,11 @@ def mat_inverse(
     -----
     The default method is "numpy" when numpy version >= 2.0.0,
     which uses the `numpy.linalg.inv` function.
-    The alternative method is "manual", which uses a manual implementation of
-    the inversion algorithm. The manual method is used to avoid a performance
+    The alternative method is "python", which uses a pure python implementation of
+    the inversion algorithm. The python method is used to avoid a performance
     issue with `numpy.linalg.inv` on some platforms when numpy version < 2.0.0.
     See: https://github.com/pygfx/pygfx/issues/763
-    The manual method is slower than the numpy method, but it is guaranteed to work.
+    The python method is slower than the numpy method, but it is guaranteed to work.
 
     When the matrix is singular, it will return a matrix filled with zeros,
     This is a common behavior in real-time graphics applications.
@@ -899,7 +899,7 @@ def mat_inverse(
 
     fn = {
         "numpy": np.linalg.inv,
-        "manual": _mat_inv,
+        "python": _mat_inv,
     }[method]
 
     matrix = np.asarray(matrix)
@@ -908,9 +908,7 @@ def mat_inverse(
     except np.linalg.LinAlgError:
         inverse = np.zeros_like(matrix, dtype=dtype)
     if out is None:
-        if dtype is not None:
-            return inverse.astype(dtype, copy=False)
-        return inverse
+        return np.asarray(inverse, dtype=dtype)
     else:
         out[:] = inverse
     return out

--- a/pylinalg/misc.py
+++ b/pylinalg/misc.py
@@ -131,7 +131,7 @@ def quat_to_axis_angle(quaternion, /, *, out=None, dtype=None) -> np.ndarray:
     quaternion = np.asarray(quaternion)
 
     if out is None:
-        quaternion = quaternion.astype(dtype)
+        quaternion = quaternion.astype(dtype, copy=False)
         out = (
             quaternion[..., :3] / np.sqrt(1 - quaternion[..., 3] ** 2),
             2 * np.arccos(quaternion[..., 3]),

--- a/pylinalg/vector.py
+++ b/pylinalg/vector.py
@@ -170,10 +170,9 @@ def vec_unproject(
     if not matrix_is_inv:
         from .matrix import mat_inverse
 
-        try:
-            inverse_projection = mat_inverse(matrix)
-        except np.linalg.LinAlgError as err:
-            raise ValueError("The provided matrix is not invertible.") from err
+        inverse_projection = mat_inverse(matrix)
+        if np.all(inverse_projection == 0):
+            raise ValueError("The provided matrix is not invertible.")
 
     vector_hom = np.empty((*result_shape, 4), dtype=dtype)
     vector_hom[..., 2] = depth

--- a/pylinalg/vector.py
+++ b/pylinalg/vector.py
@@ -167,7 +167,9 @@ def vec_unproject(
     if out is None:
         out = np.empty((*result_shape, 3), dtype=dtype)
 
-    if not matrix_is_inv:
+    if matrix_is_inv:
+        inverse_projection = matrix
+    else:
         from .matrix import mat_inverse
 
         inverse_projection = mat_inverse(matrix, raise_err=True)

--- a/pylinalg/vector.py
+++ b/pylinalg/vector.py
@@ -170,9 +170,7 @@ def vec_unproject(
     if not matrix_is_inv:
         from .matrix import mat_inverse
 
-        inverse_projection = mat_inverse(matrix)
-        if np.all(inverse_projection == 0):
-            raise ValueError("The provided matrix is not invertible.")
+        inverse_projection = mat_inverse(matrix, raise_err=True)
 
     vector_hom = np.empty((*result_shape, 4), dtype=dtype)
     vector_hom[..., 2] = depth

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [project]
 name = "pylinalg"
-version = "0.6.2"
+version = "0.6.3"
 description = "Linear algebra utilities for Python"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_matrix.py
+++ b/tests/test_matrix.py
@@ -385,15 +385,15 @@ def test_mat_euler_vs_scipy():
 def test_mat_inverse():
     a = la.mat_from_translation([1, 2, 3])
     np_inv = la.mat_inverse(a, method="numpy")
-    manual_inv = la.mat_inverse(a, method="manual")
-    npt.assert_array_equal(np_inv, manual_inv)
+    python_inv = la.mat_inverse(a, method="python")
+    npt.assert_array_equal(np_inv, python_inv)
 
     # test for singular matrix
     b = la.mat_from_scale([0, 2, 3])
     np_inv = la.mat_inverse(b, method="numpy")
-    manual_inv = la.mat_inverse(b, method="manual")
+    python_inv = la.mat_inverse(b, method="python")
     npt.assert_array_equal(np_inv, np.zeros((4, 4)))
-    npt.assert_array_equal(manual_inv, np.zeros((4, 4)))
+    npt.assert_array_equal(python_inv, np.zeros((4, 4)))
 
 
 def test_mat_has_shear():

--- a/tests/test_pylinalg.py
+++ b/tests/test_pylinalg.py
@@ -58,9 +58,9 @@ def test_api():
         # confirm the signature of each callable
         sig = inspect.signature(getattr(la, key))
 
-        assert (
-            sig.return_annotation is not inspect.Signature.empty
-        ), f"Missing return annotation on {key}"
+        assert sig.return_annotation is not inspect.Signature.empty, (
+            f"Missing return annotation on {key}"
+        )
         if sig.return_annotation is bool:
             key_parts = key.split("_")
             assert key_parts[1] in ("is", "has")
@@ -77,9 +77,9 @@ def test_api():
                     assert param.KEYWORD_ONLY
                     has_out = True
             assert has_out, f"Function {key} does not have 'out' keyword-only argument"
-            assert (
-                has_dtype
-            ), f"Function {key} does not have 'dtype' keyword-only argument"
+            assert has_dtype, (
+                f"Function {key} does not have 'dtype' keyword-only argument"
+            )
 
     # assert that all callables are available in __all__
     assert set(__all__) == set(callables)

--- a/tests/test_vectors.py
+++ b/tests/test_vectors.py
@@ -303,6 +303,16 @@ def test_vec_unproject_exceptions():
         la.vec_unproject(vector, matrix)
 
 
+def test_vec_unproject_is_inverse():
+    a = la.mat_perspective(-1, 1, -1, 1, 1, 100)
+    a_inv = la.mat_inverse(a)
+    vecs = np.array([[1, 2], [4, 5], [7, 8]])
+
+    expected = la.vec_unproject(vecs, a)
+    actual = la.vec_unproject(vecs, a_inv, matrix_is_inv=True)
+    npt.assert_array_equal(expected, actual)
+
+
 def test_vector_apply_rotation_ordered():
     """Test that a positive pi/2 rotation about the z-axis and then the y-axis
     results in a different output then in standard rotation ordering."""


### PR DESCRIPTION
* Rename matrix inversion method "manual" to "python"
* Reduce a few more matrix allocations
* Add option to mat_inverse to raise an error if the matrix is invertible. The default remains returning all zeros.
* Add option to vec_unproject to skip matrix inversion.
* Bump version